### PR TITLE
Fix: MEJORAR BUSCADOR PRODUCTOS STOCK/CARRITO

### DIFF
--- a/src/pages/Sales/Sales.tsx
+++ b/src/pages/Sales/Sales.tsx
@@ -84,9 +84,20 @@ export const Sales = () => {
 
         if (searchText.trim()) {
             const lower = searchText.trim().toLowerCase();
-            filtered = filtered.filter(p =>
-                (p.producto ?? '').toString().toLowerCase().includes(lower)
-            );
+            const words = lower.split(" ");
+            const specialChars = /[!@#$%^&*?:{}|<>]/
+
+            const filterWords = (p: any, words: string[]) => {
+                let match = true;
+                for (const word of words) {
+                    if (!match) return false;
+                    if (specialChars.test(word)) continue;
+                    match = match && (p.producto ?? '').toString().toLowerCase().includes(word);
+                }
+                return match;
+            };
+
+            filtered = filtered.filter(p => filterWords(p, words));
         }
         filtered = filtered.map((p: any) => {
             const vendedor = sellers.find((v: any) => String(v._id) === String(p.id_vendedor));

--- a/src/pages/StockManagement/ProductTable.tsx
+++ b/src/pages/StockManagement/ProductTable.tsx
@@ -208,8 +208,15 @@ const ProductTable = ({ productsList, groupList, onUpdateProducts, setStockListF
 
             const baseName = product.nombre_producto;
 
-            const nombreMatch = baseName?.toLowerCase().includes(searchText.toLowerCase());
-            const varianteMatch = product.variant?.toLowerCase().includes(searchText.toLowerCase());
+            const searchWords = searchText.split(" ");
+            const specialChars = /[!@#$%^&*?:{}|<>]/
+            let nombreMatch = true;
+            let varianteMatch = true;
+            for (const word of searchWords) {
+                if (specialChars.test(word)) continue
+                nombreMatch = nombreMatch && baseName?.toLowerCase().includes(word.toLowerCase());
+                varianteMatch = varianteMatch && product.variant?.toLowerCase().includes(word.toLowerCase());
+            }
 
             if (searchText && !nombreMatch && !varianteMatch) return;
 


### PR DESCRIPTION
# Bug
Tanto el buscador de Carrito como el de Stock no permiten la búsqueda de productos con las palabras en desorden, es decir, se busca la cadena completa encerrada en el buscador, excluyendo los nombres que tengan el mismo contenido pero en distinto orden.

# Fix
Se separa la cadena de entrada en las palabras que la forman (ignorando aquellas con caracteres especiales) y se buscan productos que contengan dichas palabras dentro de su nombre. Si una de las palabras no se encuentra dentro del nombre del producto, se descarta este producto para la búsqueda y se prosigue con los demás.