### PR TITLE
Feat: FUNCION PARA QUE LOS CLIENTES SUBAN SUS GUIAS DE ENVIO POR FLOTA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@react-pdf/renderer": "^3.4.4",
         "antd": "^5.19.1",
         "axios": "^1.7.2",
+        "buffer": "^6.0.3",
         "core-js": "^3.38.1",
         "dayjs": "^1.11.12",
         "jspdf": "^2.5.2",
@@ -2399,6 +2400,30 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3481,6 +3506,26 @@
       "version": "1.10.4",
       "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.10.4.tgz",
       "integrity": "sha512-SejXzIpv9gOVdDWXd4suM1fdF1k2dxZGvuTdkOVLoazYfK7O4DykIQbdrvuyG+EaTNlXAGhMndtKrhykgbt0gg=="
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@react-pdf/renderer": "^3.4.4",
     "antd": "^5.19.1",
     "axios": "^1.7.2",
+    "buffer": "^6.0.3",
     "core-js": "^3.38.1",
     "dayjs": "^1.11.12",
     "jspdf": "^2.5.2",

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -8,3 +8,8 @@ export const apiClient = axios.create({
     "Content-Type": "application/json",
   },
 });
+
+export const apiClientNoJSON = axios.create({
+  baseURL: SERVER_URL,
+  withCredentials: true, // para las cookies
+});

--- a/src/api/shippingGuide.ts
+++ b/src/api/shippingGuide.ts
@@ -40,8 +40,22 @@ const registerShippingGuideAPI = async (formData: any) => {
     }
 } 
 
+const markAsDelivered = async (shippingGuideID: string) => {
+    try {
+        await apiClient.put(`/shippingGuide/mark-deliver/${shippingGuideID}`)
+        return {success: true}
+    } catch (error) {
+        const err = error as AxiosError;
+        if (err && err.response && err.response.data) {
+            return {success: false, ...err.response.data};
+        }
+        return {success: false}
+    }
+}
+
 export {
     getShippingGuidesAPI,
     getShippingGuidesBySellerAPI,
     registerShippingGuideAPI,
+    markAsDelivered,
 }

--- a/src/api/shippingGuide.ts
+++ b/src/api/shippingGuide.ts
@@ -14,6 +14,19 @@ const getShippingGuidesAPI = async () => {
     }
 }
 
+const getShippingGuidesBySellerAPI = async(sellerID: string) => {
+    try {
+        const res = await apiClient.get(`/shippingGuide/seller/${sellerID}`);
+        return res.data;
+    } catch (error) {
+        const err = error as AxiosError;
+        if (err && err.response && err.response.data) {
+            return {success: false, ...err.response.data};
+        }
+        return {success: false}
+    }
+}
+
 const registerShippingGuideAPI = async (formData: any) => {
     try {
         const res = await apiClientNoJSON.post("/shippingGuide/upload", formData);
@@ -29,5 +42,6 @@ const registerShippingGuideAPI = async (formData: any) => {
 
 export {
     getShippingGuidesAPI,
+    getShippingGuidesBySellerAPI,
     registerShippingGuideAPI,
 }

--- a/src/api/shippingGuide.ts
+++ b/src/api/shippingGuide.ts
@@ -1,0 +1,33 @@
+import { AxiosError } from "axios";
+import { apiClient, apiClientNoJSON } from "./apiClient";
+
+const getShippingGuidesAPI = async () => {
+    try {
+        const res = await apiClient.get("/shippingGuide");
+        return res.data;
+    } catch (error) {
+        const err = error as AxiosError;
+        if (err && err.response && err.response.data) {
+            return {success: false, ...err.response.data};
+        }
+        return {success: false}
+    }
+}
+
+const registerShippingGuideAPI = async (formData: any) => {
+    try {
+        const res = await apiClientNoJSON.post("/shippingGuide/upload", formData);
+        return {success: true, ...res.data};
+    } catch (error) {
+        const err = error as AxiosError;
+        if (err && err.response && err.response.data) {
+            return {success: false, ...err.response.data};
+        }
+        return {success: false}
+    }
+} 
+
+export {
+    getShippingGuidesAPI,
+    registerShippingGuideAPI,
+}

--- a/src/constants/menu.ts
+++ b/src/constants/menu.ts
@@ -73,5 +73,11 @@ export const menu = [
     label: "Usuarios",
     icon: sellerIcon,
     roles: ["admin"],
+  },
+  {
+    path: "/shipping-guide",
+    label: "Guías de Envío",
+    icon: shippingIcon,
+    roles: ["seller"]
   }
 ];

--- a/src/pages/ShippingGuide/ShippinGuide.tsx
+++ b/src/pages/ShippingGuide/ShippinGuide.tsx
@@ -1,0 +1,38 @@
+import { useContext, useState } from "react";
+import { UserContext } from "../../context/userContext.tsx";
+import { Button } from 'antd';
+import UploadGuideModal from "./UploadGuideModal.tsx";
+
+const ShippingGuide = () => {
+    const [isUploadGuideModalView, setIsUploadGuideModalView] = useState(false);
+
+    const { user } = useContext(UserContext);
+    const isAdmin = user?.role?.toLowerCase() === 'admin';
+
+    return (
+        <div className="p-4">
+            <div className="flex justify-between items-center mb-4">
+                <div className="flex items-center gap-3 bg-white rounded-xl px-5 py-2 shadow-md">
+                    <img src="/box-icon.png" alt="Pedidos" className="w-8 h-8" />
+                    <h1 className="text-mobile-3xl xl:text-desktop-3xl font-bold text-gray-800">
+                        Guías de Envío
+                    </h1>
+                </div>
+            </div>
+            {!isAdmin && (
+                <Button 
+                    type="primary"
+                    onClick={() => {setIsUploadGuideModalView(true)}}>
+                    Subir nueva guía
+                </Button>
+            )}
+            <UploadGuideModal 
+                visible={isUploadGuideModalView} 
+                onCancel={() => {setIsUploadGuideModalView(false)}}
+                onFinish={() => {console.log("TODO actualiza la tabla")}}
+            />
+        </div>
+    );
+}
+
+export default ShippingGuide

--- a/src/pages/ShippingGuide/ShippinGuide.tsx
+++ b/src/pages/ShippingGuide/ShippinGuide.tsx
@@ -2,12 +2,20 @@ import { useContext, useState } from "react";
 import { UserContext } from "../../context/userContext.tsx";
 import { Button } from 'antd';
 import UploadGuideModal from "./UploadGuideModal.tsx";
+import ShippingGuideTable from "./ShippingGuideTable.tsx";
 
 const ShippingGuide = () => {
     const [isUploadGuideModalView, setIsUploadGuideModalView] = useState(false);
+    const [refreshKey, setRefreshKey] = useState(0)
 
     const { user } = useContext(UserContext);
     const isAdmin = user?.role?.toLowerCase() === 'admin';
+
+    const handleFinish = () => {
+        setRefreshKey(prevKey => prevKey + 1);
+        setIsUploadGuideModalView(false); 
+        console.log("key",refreshKey)
+    };
 
     return (
         <div className="p-4">
@@ -20,16 +28,23 @@ const ShippingGuide = () => {
                 </div>
             </div>
             {!isAdmin && (
-                <Button 
+                <Button
                     type="primary"
-                    onClick={() => {setIsUploadGuideModalView(true)}}>
+                    onClick={() => { setIsUploadGuideModalView(true) }}>
                     Subir nueva guía
                 </Button>
             )}
-            <UploadGuideModal 
-                visible={isUploadGuideModalView} 
-                onCancel={() => {setIsUploadGuideModalView(false)}}
-                onFinish={() => {console.log("TODO actualiza la tabla")}}
+            <div className="px-5 py-4">
+                <ShippingGuideTable
+                    refreshKey={refreshKey}
+                    user={user}
+                />
+            </div>
+            
+            <UploadGuideModal
+                visible={isUploadGuideModalView}
+                onCancel={() => { setIsUploadGuideModalView(false) }}
+                onFinish={handleFinish}
             />
         </div>
     );

--- a/src/pages/ShippingGuide/ShippinGuide.tsx
+++ b/src/pages/ShippingGuide/ShippinGuide.tsx
@@ -38,6 +38,8 @@ const ShippingGuide = () => {
                 <ShippingGuideTable
                     refreshKey={refreshKey}
                     user={user}
+                    isFilterBySeller
+                    id_vendedor={user.id_vendedor}
                 />
             </div>
             

--- a/src/pages/ShippingGuide/ShippingGuideTable.tsx
+++ b/src/pages/ShippingGuide/ShippingGuideTable.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from "react";
+import { Buffer } from 'buffer';
+import { getShippingGuidesAPI, getShippingGuidesBySellerAPI } from "../../api/shippingGuide";
+import { Button, Card, Col, message, Modal, Row, Table } from "antd";
+import { FileImageOutlined } from '@ant-design/icons';
+import moment from "moment-timezone";
+
+const ShippingGuideTable = ({ refreshKey, user }: { refreshKey: number, user: any }) => {
+    const [guidesList, setGuidesList] = useState([]);
+    const [imageUrl, setImageUrl] = useState<string | null>();
+    const [imageDesc, setImageDesc] = useState<string | null>();
+    const [isImageVisible, setIsImageVisible] = useState(false);
+    const [sortOrder, setSortOrder] = useState<'ascend' | 'descend'>('descend');
+
+    const isAdmin = user?.role?.toLowerCase() === 'admin';
+
+    useEffect(() => {
+        if (isAdmin) {
+            fetchAllGuides();
+        } else {
+            fetchGuidesBySeller();
+        }
+    }, [refreshKey])
+
+    const fetchAllGuides = async () => {
+        try {
+            const apiData = await getShippingGuidesAPI();
+            const sortedData = apiData.sort(
+                (a: any, b: any) => new Date(b.fecha_subida).getTime() - new Date(a.fecha_subida).getTime()
+            );
+            setGuidesList(sortedData)
+        } catch (error) {
+            console.error("Error al obtener Guías de Envío: ", error)
+            message.error("Error al cargar Guías de Envío")
+        }
+    }
+    const fetchGuidesBySeller = async () => {
+        try {
+            const apiData = await getShippingGuidesBySellerAPI(user.id_vendedor);
+            const sortedData = apiData.sort(
+                (a: any, b: any) => new Date(b.fecha_subida).getTime() - new Date(a.fecha_subida).getTime()
+            );
+            setGuidesList(sortedData)
+        } catch (error) {
+            console.error("Error al obtener Guías de Envío por vendedor: ", error)
+            message.error("Error al cargar Guías de Envío")
+        }
+    };
+
+    const handleShowImage = (record: any) => {
+        if (record.imagen) {
+            console.log(record)
+            const imageData = record.imagen.data;
+            const buffer = Buffer.from(imageData);
+            const blob = new Blob([buffer], { type: record.tipoArchivo });
+            const url = URL.createObjectURL(blob);
+            setImageUrl(url);
+            setIsImageVisible(true);
+            setImageDesc(record.descripcion)
+        }
+    }
+
+    const columns = [
+        {
+            title: 'Fecha de creación',
+            dataIndex: 'fecha_subida',
+            key: 'fecha_subida',
+            width: 200,
+            render: (text: string) => moment.parseZone(text).format("DD/MM/YYYY"),
+            sorter: (a: any, b: any) =>
+                moment.parseZone(a.fecha_pedido).valueOf() -
+                moment.parseZone(b.fecha_pedido).valueOf(),
+            sortOrder,
+            onHeaderCell: () => ({
+                onClick: () => {
+                    setSortOrder(prev => (prev === 'ascend' ? 'descend' : 'ascend'));
+                },
+            }),
+        },
+        {
+            title: 'Descripción',
+            dataIndex: 'descripcion',
+            key: 'descripcion',
+            render: (_: any, record: any) => {
+                if (record.descripcion == "undefined") {
+                    return "Sin descripción"
+                } else {
+                    return record.descripcion
+                }
+            }
+        },
+        {
+            title: 'Acciones',
+            dataIndex: 'imagen',
+            key: 'imagen',
+            render: (_: any, record: any) => {
+                return (
+                    <>
+                        <Button onClick={() => { handleShowImage(record) }}>
+                            <FileImageOutlined />Ver foto
+                        </Button>
+                    </>
+                )
+            }
+        }
+    ];
+
+    return (
+        <>
+            <Table
+                columns={columns}
+                dataSource={guidesList}
+                scroll={{ x: "max-content" }}
+            />
+
+            <Modal
+                open={isImageVisible}
+                onCancel={() => {
+                    setIsImageVisible(false)
+                    setImageUrl(null)
+                    setImageDesc(null)
+                }}
+                footer={null}
+            >
+                <Card title="Foto - Guía de Envío" bordered={false}>
+                    <Row gutter={16}>
+                        {imageUrl && <img src={imageUrl} alt="Imagen" style={{ width: '100%' }} />}
+                    </Row>
+                    <div className="py-4">
+                        <Row gutter={16}>
+                            <Col>
+                                {imageDesc}
+                            </Col>
+                        </Row>
+                    </div>
+                </Card>
+
+            </Modal>
+        </>
+    )
+}
+
+export default ShippingGuideTable;

--- a/src/pages/ShippingGuide/ShippingGuideTable.tsx
+++ b/src/pages/ShippingGuide/ShippingGuideTable.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 import { Buffer } from 'buffer';
 import { getShippingGuidesAPI, getShippingGuidesBySellerAPI } from "../../api/shippingGuide";
-import { Button, Card, Col, message, Modal, Row, Table } from "antd";
-import { FileImageOutlined } from '@ant-design/icons';
+import { Button, Card, Col, message, Modal, Row, Table, Tooltip } from "antd";
+import { FileImageOutlined, CheckCircleOutlined } from '@ant-design/icons';
 import moment from "moment-timezone";
 
-const ShippingGuideTable = ({ refreshKey, user }: { refreshKey: number, user: any }) => {
+const ShippingGuideTable = (
+    { refreshKey, user, isFilterBySeller, id_vendedor }:
+        { refreshKey: number, user: any, isFilterBySeller: boolean, id_vendedor: string }) => {
     const [guidesList, setGuidesList] = useState([]);
     const [imageUrl, setImageUrl] = useState<string | null>();
     const [imageDesc, setImageDesc] = useState<string | null>();
@@ -15,7 +17,7 @@ const ShippingGuideTable = ({ refreshKey, user }: { refreshKey: number, user: an
     const isAdmin = user?.role?.toLowerCase() === 'admin';
 
     useEffect(() => {
-        if (isAdmin) {
+        if (!isFilterBySeller) {
             fetchAllGuides();
         } else {
             fetchGuidesBySeller();
@@ -36,7 +38,7 @@ const ShippingGuideTable = ({ refreshKey, user }: { refreshKey: number, user: an
     }
     const fetchGuidesBySeller = async () => {
         try {
-            const apiData = await getShippingGuidesBySellerAPI(user.id_vendedor);
+            const apiData = await getShippingGuidesBySellerAPI(id_vendedor);
             const sortedData = apiData.sort(
                 (a: any, b: any) => new Date(b.fecha_subida).getTime() - new Date(a.fecha_subida).getTime()
             );
@@ -60,6 +62,10 @@ const ShippingGuideTable = ({ refreshKey, user }: { refreshKey: number, user: an
         }
     }
 
+    const handleCheckShipping = (record: any) => {
+        //TODO - Relación con pedidos?
+    }
+
     const columns = [
         {
             title: 'Fecha de creación',
@@ -68,8 +74,8 @@ const ShippingGuideTable = ({ refreshKey, user }: { refreshKey: number, user: an
             width: 200,
             render: (text: string) => moment.parseZone(text).format("DD/MM/YYYY"),
             sorter: (a: any, b: any) =>
-                moment.parseZone(a.fecha_pedido).valueOf() -
-                moment.parseZone(b.fecha_pedido).valueOf(),
+                moment.parseZone(a.fecha_subida).valueOf() -
+                moment.parseZone(b.fecha_subida).valueOf(),
             sortOrder,
             onHeaderCell: () => ({
                 onClick: () => {
@@ -96,9 +102,23 @@ const ShippingGuideTable = ({ refreshKey, user }: { refreshKey: number, user: an
             render: (_: any, record: any) => {
                 return (
                     <>
-                        <Button onClick={() => { handleShowImage(record) }}>
-                            <FileImageOutlined />Ver foto
-                        </Button>
+                        {record.imagen && (
+                            <Tooltip title="Ver foto">
+                                <Button
+                                    size="small"
+                                    icon={<FileImageOutlined />}
+                                    onClick={() => { handleShowImage(record) }}
+                                />
+                            </Tooltip>
+                        )}
+                        {isAdmin && (
+                            <Tooltip title="Confirmar entrega">
+                                <Button 
+                                    size="small"
+                                    icon={<CheckCircleOutlined />}
+                                    onClick={() => { handleCheckShipping(record) }}/>
+                            </Tooltip>
+                        )}
                     </>
                 )
             }

--- a/src/pages/ShippingGuide/UploadGuideModal.tsx
+++ b/src/pages/ShippingGuide/UploadGuideModal.tsx
@@ -1,0 +1,111 @@
+import { Card, Col, Form, Modal, Row, Input, Upload, Button, message, DatePicker } from "antd";
+import { useContext, useState } from "react";
+import { UserContext } from "../../context/userContext.tsx";
+import { MessageOutlined, UploadOutlined } from '@ant-design/icons';
+import { registerShippingGuideAPI } from "../../api/shippingGuide.ts";
+import moment from 'moment';
+
+function UploadGuideModal({ visible, onCancel, onFinish }: any) {
+    const [form] = Form.useForm();
+    const { user } = useContext(UserContext);
+    const [loading, setLoading] = useState(false);
+
+    const handleUploadChange = (info: any) => {
+        if (info.file.status === 'done') {
+            message.success(`${info.file.name} file uploaded successfully`);
+        } else if (info.file.status === 'error') {
+            message.error(`${info.file.name} file upload failed.`);
+        }
+    };
+
+    const handleFinish = async (values: any) => {
+        setLoading(true);
+        try {
+            const vendedor_id = user.id_vendedor;
+            const descripcion = values.description;
+            const imagen = values.image && values.image[0] ? values.image[0].originFileObj : null;
+
+            const formData = new FormData();
+            formData.append('vendedor', vendedor_id);
+            formData.append('descripcion', descripcion);
+            if (imagen) {
+                formData.append('imagen', imagen);
+            }
+
+            const response = await registerShippingGuideAPI(formData);
+
+            if (!response.success) {
+                message.error("Error registrando la venta");
+                setLoading(false);
+                return;
+            } else {
+                message.success("Venta externa registrada");
+                onCancel();
+            }
+        } catch (error) {
+            console.error("Error en Modal Guía de Envío: ", error);
+            message.error("Error procesando la guía");
+        }
+        setLoading(false);
+        form.resetFields();
+        onFinish();
+    };
+
+
+    const handleCancel = () => {
+        form.resetFields();
+        onCancel();
+    };
+
+    return (
+        <Modal title="Guía de Envío" open={visible} onCancel={handleCancel} width={700} footer={null}>
+            <Form form={form} name="uploadGuideForm" onFinish={handleFinish} layout='vertical'>
+                <Card title="Información Básica" bordered={false}>
+                    <Row gutter={16}>
+                        <Col span={12}>
+                            <Form.Item name='fecha_subida' label='Fecha de Subida'>
+                                <DatePicker
+                                    style={{ width: '100%' }}
+                                    disabled={true}
+                                    defaultValue={moment()}
+                                />
+                            </Form.Item>
+                        </Col>
+                    </Row>
+                </Card>
+                <Card title="Datos Opcionales" bordered={false}>
+                    <Row gutter={16}>
+                        <Col span={12}>
+                            <Form.Item name='description' label='Descripción' rules={[{ required: false }]}>
+                                <Input
+                                    prefix={<MessageOutlined />}
+                                />
+                            </Form.Item>
+                        </Col>
+                    </Row>
+                    <Row gutter={16}>
+                        <Col span={12}>
+                            <Form.Item name='image' label='Foto de la Guía' valuePropName="fileList" getValueFromEvent={e => Array.isArray(e) ? e : e && e.fileList} rules={[{ required: false }]}>
+                                <Upload
+                                    name="image"
+                                    accept="image/*"
+                                    beforeUpload={() => false}
+                                    onChange={handleUploadChange}
+                                >
+                                    <Button icon={<UploadOutlined />}>Seleccionar Imagen</Button>
+                                </Upload>
+                            </Form.Item>
+                        </Col>
+                    </Row>
+                </Card>
+                <Form.Item style={{ marginTop: 16 }}>
+                    <Button type="primary" htmlType="submit" loading={loading}>
+                        Guardar
+                    </Button>
+                </Form.Item>
+            </Form>
+        </Modal>
+    );
+}
+
+export default UploadGuideModal;

--- a/src/routes/protectedRoutes.tsx
+++ b/src/routes/protectedRoutes.tsx
@@ -16,6 +16,7 @@ import BranchPage from "../pages/Branch/BranchPage";
 import SalesHistoryPage from "../pages/SalesHistory/SalesHistoryPage";
 import UsersPage from "../pages/Users/UsersPage";
 import ServicesPage from "../pages/Service/ServicePanelPage";
+import ShippingGuide from "../pages/ShippingGuide/ShippinGuide";
 
 const protectedRoutes = [
   {
@@ -154,6 +155,14 @@ const protectedRoutes = [
             <UsersPage />
           </RoleGuard>
         ),
+      },
+      {
+        path: "/shipping-guide",
+        element: (
+          <RoleGuard allowedRoles={["seller"]}>
+            <ShippingGuide/>
+          </RoleGuard>
+        )
       },
       {
         path: "*",


### PR DESCRIPTION
# Requisitos
- Añadir una funcion donde los vendedores suban foto de sus guías de envío de productos.
- Para la vista del vendedor: una lista de las guias antiguas y una columna que indique si ya se recogio el paquete y la fecha en que se subio la guia, ademas debe aparecer un boton para añadir la foto de una guia. (una vez subida la guia, ellos no pueden modificar ni borrar nada)
- Para los admins y personal debe aparecer la misma lista, pero no el boton para añadir. ademas cada guia debe tener un boton con el cual se pueda confirmar que ya se recogio el envio. (si es posible, que las guias se borren pasado un mes a partir del dia de recojo)

# Código nuevo
##  Página principal `ShippinGuide.tsx`
Se agregó una nueva página destinada a mostrar los contenidos de las guías de envío, cuenta con un botón para subir una nueva guía y un componente tabla para mostrar las guías del vendedor
## Tabla de Guías `ShippingGuideTable.tsx`
Este componente muestra las guías de envio subidas, mostrando su fecha de subida, su descripción y permitiendo abrir la imágen asociada a esta.
## Formulario de Creación de guías `UploadGuideModal.tsx`
Se creó un simple formulario para crear nuevas guías de envío, este se encuentra disponible únicamente para los vendedores a través del botón de creación de guías encontrado en la página de Guías de Envío. 
>[!Tip]
>A falta de información obligatoria (con excepción del vendedor y la fecha, ambos fácilmente autocompletables) el formulario puede subirse sin agregar información adicional.
## API `shippingGuide.ts`
Se agregaron las conexiones API correspondientes a las guías de envío, entre las que se encuentra la obtención de todas las guías, obtención de guías por vendedor y publicación de una nueva guía.
>[!Warning]
>Tanto para el titular de la página como para el menú lateral se emplearon iconos ya usados por otros modulos

# Cambios realizados
## Tabla de Guías por Vendedor `SellerTable.tsx`
Se agregó un botón de acción para poder acceder a las guías de envío subidas por determinado vendedor, esto a través de la tabla ubicada en la vista de Vendedores en el rol de administradores. 
## Cambios en `menu.ts` y `protectedRoutes`
Se creó una nueva ruta para la nueva página de Guías de Envío, disponible únicamente para los vendedores a través del menú lateral. Si bien los admins no tienen acceso a esta pantalla, pueden ver la información relevante desde la pestaña de vendedores.
## Cambios en `apiClient.ts`
Para permitir la subida de imágenes y archivos se requiere de emplear otro formato de envío de solicitudes al Backend, operación que no era posible con la implementación actual de apiClient, por lo que se creó otra similar pero sin las restricciones de formato:
```ts
export const apiClientNoJSON = axios.create({
  baseURL: SERVER_URL,
  withCredentials: true, // para las cookies
});
```
La implementación original de apiClient sigue disponible
## Cambios en `package-lock.json` y `package.json`
Se agregó una librería que permite volver a construir imágenes en formato Buffer para mostrarlas en la página.
>[!Warning]
>Guardar imágenes de este modo puede resultar pesado, además de que las respuestas JSON desde Backend se vuelven bastante grandes. Se recomienda contemplar el uso de servicios como AWS para alojar las imágenes.