### PR TITLE
Feat: HORA ENTREGA QUE SEA RANGO

### DIFF
--- a/src/pages/Sales/ShippingFormmodal.tsx
+++ b/src/pages/Sales/ShippingFormmodal.tsx
@@ -366,7 +366,10 @@ function ShippingFormModal({
                             />
                         </div>
                         <Col span={12}>
-                            <Form.Item name="hora_entrega_acordada" label="Hora Entrega">
+                            <Form.Item 
+                                name="hora_entrega_acordada" 
+                                label={isRangeHour? "Inicio del Rango Horario":"Hora de Entrega"}
+                            >
                                 <TimePicker format='HH:mm' style={{ width: '100%' }} />
                             </Form.Item>
                         </Col>

--- a/src/pages/Sales/ShippingFormmodal.tsx
+++ b/src/pages/Sales/ShippingFormmodal.tsx
@@ -1,4 +1,4 @@
-import { Modal, Form, Input, InputNumber, Button, Radio, Col, Row, DatePicker, TimePicker, Card, message, Select } from 'antd';
+import { Modal, Form, Input, InputNumber, Button, Radio, Col, Row, DatePicker, TimePicker, Card, message, Select, Switch } from 'antd';
 import { UserOutlined, PhoneOutlined, CommentOutlined, PlusOutlined, MinusOutlined } from '@ant-design/icons';
 import {useEffect, useMemo, useState} from 'react';
 import { registerShippingAPI, updateShippingAPI  } from '../../api/shipping';
@@ -38,6 +38,7 @@ function ShippingFormModal({
     const [showWarning, setShowWarning] = useState(false);
     const [quienPaga, setQuienPaga] = useState<string | null>(null);
     const [estaPagado, setEstaPagado] = useState<string | null>(null);
+    const [isRangeHour, setIsRangeHour] = useState(false);
     const [allSucursals, setAllSucursals] = useState([]);
     const sucursalId = localStorage.getItem('sucursalId');
     const sucursalLogueada = allSucursals.find((s: any) => s._id === sucursalId);
@@ -351,11 +352,31 @@ function ShippingFormModal({
                                 <DatePicker style={{ width: '100%' }} />
                             </Form.Item>
                         </Col>
+                    </Row>
+                    <Row gutter={16}>
+                        <div style={{ margin:8 }}>
+                            <span style={{ marginRight:8 }}>
+                                - ¿Acordar entrega en un rango de horas?
+                            </span>
+                            <Switch
+                                checked={isRangeHour}
+                                onChange={(checked) => { setIsRangeHour(checked); }}
+                                unCheckedChildren="Hora específica"
+                                checkedChildren="Rango de horas"
+                            />
+                        </div>
                         <Col span={12}>
                             <Form.Item name="hora_entrega_acordada" label="Hora Entrega">
                                 <TimePicker format='HH:mm' style={{ width: '100%' }} />
                             </Form.Item>
                         </Col>
+                        {isRangeHour && (
+                            <Col span={12}>
+                                <Form.Item name="hora_entrega_rango_final" label="Fin del Rango Horario">
+                                    <TimePicker format='HH:mm' style={{ width: '100%' }} />
+                                </Form.Item>
+                            </Col>
+                        )}
                     </Row>
                     <Row gutter={16}>
                         <Col span={24}>

--- a/src/pages/Shipping/ShippingInfoModal.tsx
+++ b/src/pages/Shipping/ShippingInfoModal.tsx
@@ -2,7 +2,7 @@ import TempProductModal from './TempProductModal';
 import { useEffect, useState, useMemo } from 'react';
 import {
     Modal, Card, Button, Form, Input, DatePicker, Row, Col, TimePicker,
-    Radio, Select, InputNumber, message
+    Radio, Select, InputNumber, message, Switch
 } from 'antd';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
@@ -38,6 +38,7 @@ const ShippingInfoModal = ({ visible, onClose, shipping, onSave, sucursals = [],
     const [estadoPedido, setEstadoPedido] = useState<string | null>(null);
     const [tipoPago, setTipoPago] = useState<string | null>(null);
     const [estadoInicialPedido, setEstadoInicialPedido] = useState<string | null>(null);
+    const [isRangeHour, setIsRangeHour] = useState(false);
     const [qrInput, setQrInput] = useState<number>(0);
     const [efectivoInput, setEfectivoInput] = useState<number>(0);
     const [showWarning, setShowWarning] = useState(false);
@@ -162,6 +163,7 @@ const ShippingInfoModal = ({ visible, onClose, shipping, onSave, sucursals = [],
             internalForm.setFieldsValue({
                 fecha_entrega: ahora,
                 hora_entrega_acordada: ahora,
+                hora_entrega_rango_final: ahora
             });
         }
     }, [estadoPedidoForm, estadoInicialPedido]);
@@ -199,6 +201,8 @@ const ShippingInfoModal = ({ visible, onClose, shipping, onSave, sucursals = [],
         const rawFecha = shipping.hora_entrega_acordada;
         const originalHoraEntregaUTC = rawFecha ? dayjs.utc(rawFecha) : null;
 
+        setIsRangeHour(shipping.hora_entrega_rango_final)
+
         //console.log("🟢 UTC:", dayjs.utc(shipping.hora_entrega_acordada).format());
         //console.log("🟡 Local:", dayjs.utc(shipping.hora_entrega_acordada).local().format());
 
@@ -211,6 +215,7 @@ const ShippingInfoModal = ({ visible, onClose, shipping, onSave, sucursals = [],
             hora_entrega_acordada: originalHoraEntregaUTC
                 ? dayjs(originalHoraEntregaUTC.format("HH:mm:ss"), "HH:mm:ss")
                 : null,
+            hora_entrega_rango_final: shipping.hora_entrega_rango_final ? dayjs.utc(shipping.hora_entrega_rango_final, "HH:mm:ss") : null,
             observaciones: shipping.observaciones,
             estado_pedido: shipping.estado_pedido,
             quien_paga_delivery: quienPagaDeVenta,
@@ -446,13 +451,20 @@ const ShippingInfoModal = ({ visible, onClose, shipping, onSave, sucursals = [],
                 ...values,
                 lugar_entrega: values.lugar_entrega === 'otro' ? values.lugar_entrega_input : values.lugar_entrega,
                 //fecha_pedido: moment(values.fecha_pedido).tz("America/La_Paz").format('YYYY-MM-DD HH:mm:ss'),
-                hora_entrega_acordada: fechaHoraEntregaAcordada,                pagado_al_vendedor: values.esta_pagado === 'si' || values.tipo_de_pago === '3',
+                hora_entrega_acordada: fechaHoraEntregaAcordada,                
+                pagado_al_vendedor: values.esta_pagado === 'si' || values.tipo_de_pago === '3',
+                //hora_entrega_rango_final: horaEntregaRangoFinal,
                 esta_pagado: values.esta_pagado,
                 adelanto_cliente: ['si', 'no'].includes(values.esta_pagado) ? 0 : (values.adelanto_cliente || 0),
                 quien_paga_delivery: values.quien_paga_delivery,
             };
             if (values.quien_paga_delivery === "tupunto") {
                 updateShippingInfo.cargo_delivery = 0;
+            }
+            if (values.hora_entrega_rango_final) {
+                //const hora = values.hora_entrega_rango_final.format("HH:mm:ss");
+                const hora = `${fechaEntrega.format("YYYY-MM-DD")} ${values.hora_entrega_rango_final.format("HH:mm:ss")}`;
+                updateShippingInfo.hora_entrega_rango_final = hora
             }
 
             // Forzar subtotales según el tipo de pago
@@ -475,7 +487,7 @@ const ShippingInfoModal = ({ visible, onClose, shipping, onSave, sucursals = [],
                     break;
             }
 
-            //console.log("📤 Datos enviados al backend:", updateShippingInfo);
+            console.log("📤 Datos enviados al backend:", updateShippingInfo);
 
             await updateShippingAPI(updateShippingInfo, shipping._id);
             message.success("Pedido actualizado con éxito");
@@ -630,11 +642,37 @@ const ShippingInfoModal = ({ visible, onClose, shipping, onSave, sucursals = [],
                                 <DatePicker style={{ width: '100%' }} />
                             </Form.Item>
                         </Col>
+                    </Row>
+                    <Row gutter={16}>
+                        {shipping?.estado_pedido !== "Entregado" && (
+                            <div style={{ margin:8 }}>
+                            <span style={{ marginRight:8 }}>
+                                - ¿Acordar entrega en un rango de horas?
+                            </span>
+                            <Switch
+                                checked={isRangeHour}
+                                disabled={shipping?.estado_pedido === "Entregado"}
+                                onChange={(checked) => { setIsRangeHour(checked); }}
+                                unCheckedChildren="Hora específica"
+                                checkedChildren="Rango de horas"
+                            />
+                        </div>
+                        )}
                         <Col span={12}>
-                            <Form.Item name="hora_entrega_acordada" label="Hora Entrega">
+                            <Form.Item 
+                                name="hora_entrega_acordada" 
+                                label={isRangeHour? "Inicio del Rango Horario":"Hora de Entrega Específica"}
+                            >
                                 <TimePicker format='HH:mm' style={{ width: '100%' }} />
                             </Form.Item>
                         </Col>
+                        {isRangeHour && shipping?.estado_pedido !== "Entregado" && (
+                            <Col span={12}>
+                                <Form.Item name="hora_entrega_rango_final" label="Fin del Rango Horario">
+                                    <TimePicker format='HH:mm' style={{ width: '100%' }} />
+                                </Form.Item>
+                            </Col>
+                        )}
                     </Row>
                     <Row gutter={16}>
                         <Col span={24}>

--- a/src/pages/Shipping/ShippingInfoModal.tsx
+++ b/src/pages/Shipping/ShippingInfoModal.tsx
@@ -201,6 +201,9 @@ const ShippingInfoModal = ({ visible, onClose, shipping, onSave, sucursals = [],
         const rawFecha = shipping.hora_entrega_acordada;
         const originalHoraEntregaUTC = rawFecha ? dayjs.utc(rawFecha) : null;
 
+        const fechaRango = shipping.hora_entrega_rango_final
+        const originalHoraRangoUTC = fechaRango ? dayjs.utc(fechaRango) : null;
+
         setIsRangeHour(shipping.hora_entrega_rango_final)
 
         //console.log("🟢 UTC:", dayjs.utc(shipping.hora_entrega_acordada).format());
@@ -215,7 +218,9 @@ const ShippingInfoModal = ({ visible, onClose, shipping, onSave, sucursals = [],
             hora_entrega_acordada: originalHoraEntregaUTC
                 ? dayjs(originalHoraEntregaUTC.format("HH:mm:ss"), "HH:mm:ss")
                 : null,
-            hora_entrega_rango_final: shipping.hora_entrega_rango_final ? dayjs.utc(shipping.hora_entrega_rango_final, "HH:mm:ss") : null,
+            hora_entrega_rango_final: originalHoraRangoUTC
+                ? dayjs(originalHoraRangoUTC.format("HH:mm:ss"), "HH:mm:ss")
+                : null,
             observaciones: shipping.observaciones,
             estado_pedido: shipping.estado_pedido,
             quien_paga_delivery: quienPagaDeVenta,
@@ -442,6 +447,12 @@ const ShippingInfoModal = ({ visible, onClose, shipping, onSave, sucursals = [],
 
             const fechaHoraEntregaAcordada = `${fechaEntrega.format("YYYY-MM-DD")} ${horaAcordada}`;
 
+            const horaRango = values.hora_entrega_rango_final && dayjs.isDayjs(values.hora_entrega_rango_final)
+                ? values.hora_entrega_rango_final.format("HH:mm:ss")
+                : moment().format("HH:mm:ss");
+
+            const horaEntregaRangoFinal = `${fechaEntrega.format("YYYY-MM-DD")} ${horaRango}`;
+
             let horaEntregaReal = values.estado_pedido === "Entregado"
                 ? moment().tz("America/La_Paz").format("YYYY-MM-DD HH:mm:ss")
                 : fechaHoraEntregaAcordada;
@@ -453,18 +464,13 @@ const ShippingInfoModal = ({ visible, onClose, shipping, onSave, sucursals = [],
                 //fecha_pedido: moment(values.fecha_pedido).tz("America/La_Paz").format('YYYY-MM-DD HH:mm:ss'),
                 hora_entrega_acordada: fechaHoraEntregaAcordada,                
                 pagado_al_vendedor: values.esta_pagado === 'si' || values.tipo_de_pago === '3',
-                //hora_entrega_rango_final: horaEntregaRangoFinal,
+                hora_entrega_rango_final: horaEntregaRangoFinal,
                 esta_pagado: values.esta_pagado,
                 adelanto_cliente: ['si', 'no'].includes(values.esta_pagado) ? 0 : (values.adelanto_cliente || 0),
                 quien_paga_delivery: values.quien_paga_delivery,
             };
             if (values.quien_paga_delivery === "tupunto") {
                 updateShippingInfo.cargo_delivery = 0;
-            }
-            if (values.hora_entrega_rango_final) {
-                //const hora = values.hora_entrega_rango_final.format("HH:mm:ss");
-                const hora = `${fechaEntrega.format("YYYY-MM-DD")} ${values.hora_entrega_rango_final.format("HH:mm:ss")}`;
-                updateShippingInfo.hora_entrega_rango_final = hora
             }
 
             // Forzar subtotales según el tipo de pago
@@ -661,7 +667,10 @@ const ShippingInfoModal = ({ visible, onClose, shipping, onSave, sucursals = [],
                         <Col span={12}>
                             <Form.Item 
                                 name="hora_entrega_acordada" 
-                                label={isRangeHour? "Inicio del Rango Horario":"Hora de Entrega Específica"}
+                                label={
+                                    isRangeHour && shipping?.estado_pedido !== "Entregado" 
+                                    ? "Inicio del Rango Horario"
+                                    : "Hora de Entrega"}
                             >
                                 <TimePicker format='HH:mm' style={{ width: '100%' }} />
                             </Form.Item>


### PR DESCRIPTION
## Cambios realizados
- Se agregó un Switch para seleccionar la hora de entrega de un pedido, diferenciando entre un rango de horas y una hora específica.
```tsx
<div style={{ margin:8 }}>
        <span style={{ marginRight:8 }}>
                 - ¿Acordar entrega en un rango de horas?
        </span>
        <Switch
                checked={isRangeHour}
                onChange={(checked) => { setIsRangeHour(checked); }}
                unCheckedChildren="Hora específica"
                checkedChildren="Rango de horas"
         />
</div>
```
- Al marcar un pedido como entregado, ambos campos se llenan con la hora en que se marcó la entrega, pero en el formulario solo se presenta uno de los 2 campos para evitar redundancia.
```tsx
useEffect(() => {
        if (
            estadoPedidoForm === "Entregado" &&
            estadoInicialPedido !== "Entregado"
        ) {
            const ahora = dayjs().tz("America/La_Paz");
            internalForm.setFieldsValue({
                fecha_entrega: ahora,
                hora_entrega_acordada: ahora,
                hora_entrega_rango_final: ahora
            });
        }
    }, [estadoPedidoForm, estadoInicialPedido]);
```
```tsx
       {shipping?.estado_pedido !== "Entregado" && (
                            <div style={{ margin:8 }}>
                            <span style={{ marginRight:8 }}>
                                - ¿Acordar entrega en un rango de horas?
                            </span>
                            <Switch
                                checked={isRangeHour}
                                disabled={shipping?.estado_pedido === "Entregado"}
                                onChange={(checked) => { setIsRangeHour(checked); }}
                                unCheckedChildren="Hora específica"
                                checkedChildren="Rango de horas"
                            />
                        </div>
```
- Los cambios se aplicaron tanto al formulario de creación de pedidos como al formulario de edición de pedidos.
- Se sigue la lógica de otros campos de hora para el guardado y procesado de datos