### PR TITLE
Feat: add bottom menu for mobile version

### DIFF
--- a/src/assets/minusIcon.svg
+++ b/src/assets/minusIcon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="#d2d2d2" d="M18 11H6a2 2 0 0 0 0 4h12a2 2 0 0 0 0-4"/></svg>

--- a/src/assets/plusIcon.svg
+++ b/src/assets/plusIcon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256"><path fill="#d2d2d2" d="M228 128a12 12 0 0 1-12 12h-76v76a12 12 0 0 1-24 0v-76H40a12 12 0 0 1 0-24h76V40a12 12 0 0 1 24 0v76h76a12 12 0 0 1 12 12"/></svg>

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -5,6 +5,7 @@ import Header from "./Header/Header";
 import { Outlet } from "react-router-dom";
 import HeaderXS from "./Header/HeaderXS";
 import Sider from "antd/es/layout/Sider";
+import BottomMenu from "./MobileMenu/BottomMenu";
 
 const { Content } = Layout;
 
@@ -53,7 +54,7 @@ const AppLayout = () => {
         <Content className="flex flex-col bg-white p-6">
           <Outlet />
         </Content>
-
+        {isMobile && <BottomMenu />}
       </Layout>
     </Layout>
   );

--- a/src/layout/MobileMenu/BottomMenu.tsx
+++ b/src/layout/MobileMenu/BottomMenu.tsx
@@ -1,0 +1,80 @@
+import { Menu } from 'antd';
+import { menu } from "../../constants/menu";
+import { useContext, useEffect, useState } from "react";
+import { UserContext } from "../../context/userContext";
+import { Link } from 'react-router-dom';
+
+const BottomMenu = () => {
+    const { user } = useContext(UserContext)!;
+    const [menuItems, setMenuItems] = useState<any[]>([]);
+    const [plusMenuItems, setPlusMenuItems] = useState<any[]>([]);
+    const [showPlusMenu, setShowPlusMenu] = useState(false);
+
+    useEffect(() => {
+        const filteredRoleMenuItems = menu.filter((item) =>
+            item.roles.includes(user.role)
+        )
+
+        const bottomItems: any[] = [];
+        const plusItems: any[] = [];
+
+        filteredRoleMenuItems.forEach((item) => {
+            if (["Pedidos", "Stock", "Vender"].includes(item.label)) {
+                bottomItems.push(item)
+            } else {
+                plusItems.push(item)
+            }
+        })
+        setMenuItems(bottomItems);
+        setPlusMenuItems(plusItems);
+    }, [user]);
+
+    return (
+        <div className="fixed bottom-0 left-0 right-0 bg-blue shadow-lg">
+            <Menu
+                mode="horizontal"
+                style={{ margin: 0, display: 'flex', justifyContent: 'space-around', backgroundColor: '#094f89' }}
+            >
+                {menuItems.map((item) => (
+                    <Menu.Item key={item.path} style={{ flex: 1, textAlign: 'center' }}>
+                        <Link
+                            to={item.path}
+                            className="flex flex-col items-center bg-blue hover:bg-light-blue/10 transition-colors duration-200 pt-4"
+                        >
+                            <img src={item.icon} alt={item.label} className="w-6 h-6 mb-1" />
+                            <p className='text-gray-200'>{item.label}</p>
+                        </Link>
+                    </Menu.Item>
+                ))}
+                <Menu.Item key="plus" style={{ flex: 1, textAlign: 'center' }} onClick={() => setShowPlusMenu(!showPlusMenu)}>
+                    {showPlusMenu ? (
+                        <div className="flex flex-col items-center bg-blue hover:bg-light-blue/10 transition-colors duration-200 pt-4">
+                            <img src="src/assets/minusIcon.svg" alt="Más" className="w-6 h-6 mb-1" />
+                            <p className='text-gray-200'>Menos</p>
+                        </div>
+                    ) : (
+                        <div className="flex flex-col items-center bg-blue hover:bg-light-blue/10 transition-colors duration-200 pt-4">
+                            <img src="src/assets/plusIcon.svg" alt="Más" className="w-6 h-6 mb-1" />
+                            <p className='text-gray-200'>Más</p>
+                        </div>
+                    )}
+                </Menu.Item>
+            </Menu>
+            {showPlusMenu && (
+                <div className="bg-blue-300 p-2">
+                    {plusMenuItems.map((item) => (
+                        <Link
+                            to={item.path}
+                            key={item.path}
+                            className="flex flex-col items-center bg-blue hover:bg-light-blue/10 transition-colors duration-200  pt-4"
+                        >
+                            {item.label}
+                        </Link>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default BottomMenu;


### PR DESCRIPTION
- Se agregó un menú inferior para la versión mobile del proyecto, desde este menú se puede acceder a las páginas más importantes
- Se incluye un botón "Más" para mostrar el resto de opciones del menú
<img width="588" height="781" alt="image" src="https://github.com/user-attachments/assets/d935a7c5-bd19-4915-af9d-76805ad119b1" />
<img width="590" height="781" alt="image" src="https://github.com/user-attachments/assets/ca15e72c-93c0-4e99-b05f-4df1467d6086" />
